### PR TITLE
🔧 chore(issue-tmpl): fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/language_request.yml
+++ b/.github/ISSUE_TEMPLATE/language_request.yml
@@ -1,6 +1,6 @@
 name: Request a New Language
 description: Use this template for requesting a new language.
-title: "[Langauge] Request New Language `<locale-code>`"
+title: "[Language] Request New Language `<locale-code>`"
 labels: [ "new language" ]
 body:
   - type: textarea


### PR DESCRIPTION
Fixed typo from `Langauge` to `Language` in language_request.yml.

Synced from: https://github.com/localizethedocs/clang-docs-l10n/commit/c90abc6e29c146f6a5d740ca98284f0fa4ad81c8